### PR TITLE
Fix custom panel height on Home Assistant 2026.8

### DIFF
--- a/src/ha-panel-ingress.ts
+++ b/src/ha-panel-ingress.ts
@@ -66,6 +66,10 @@ class HaPanelIngress extends HTMLElement {
   }
 
   public connectedCallback() {
+    this.style.display = "block";
+    this.style.height = "100vh";
+    this.style.height = "100dvh";
+
     if (this._isHassio) {
       ingressSession.init(this._isHassio);
     }


### PR DESCRIPTION
## Summary

Fix `ha-panel-ingress` panels collapsing to the browser's default iframe height after the Home Assistant 2026.8 frontend custom-panel layout changes.

The integration's toolbar panel renders an iframe with `height: 100%`, but the `ha-panel-ingress` host did not establish a block-level element with a definite viewport height. This makes the percentage-height chain indefinite in the updated frontend.

The host now establishes block-level viewport sizing in `connectedCallback()`:

- `display: block`
- `height: 100vh` fallback
- `height: 100dvh` where supported

The sizing is deliberately applied in `connectedCallback()`, not the custom-element constructor, because Chromium rejects custom-element upgrades when the constructor sets attributes/styles.

This change is made in `src/ha-panel-ingress.ts` as requested. The `frontend` branch's build workflow will regenerate `custom_components/ingress/www/entrypoint.js` on merge.

## Verification

- `pnpm install --frozen-lockfile` (pnpm 9.15.0)
- `pnpm run build`
- `git diff --check`
- Verified on Home Assistant 2026.8.0b5 with `ui_mode: toolbar`:
  - Frigate rendered full-height and loaded camera views.
  - Zigbee2MQTT rendered full-height and loaded the dashboard.
  - `ha-panel-ingress` computed height: 1279px; iframe computed height: 1214px.

Supersedes #104.
